### PR TITLE
Add simple auth, profile, admin codes and new games

### DIFF
--- a/frontend/src/AdminPanel.js
+++ b/frontend/src/AdminPanel.js
@@ -1,0 +1,39 @@
+import React, { useState } from 'react';
+
+function AdminPanel() {
+  const [code, setCode] = useState('');
+  const [amount, setAmount] = useState(100);
+  const [message, setMessage] = useState('');
+
+  const createCode = () => {
+    const codes = JSON.parse(localStorage.getItem('codes') || '{}');
+    codes[code] = parseInt(amount);
+    localStorage.setItem('codes', JSON.stringify(codes));
+    setMessage(`Created code ${code} worth ${amount}`);
+    setCode('');
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h2 className="text-2xl mb-4">Admin Panel</h2>
+      <div className="mb-4">
+        <input
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="New code"
+          className="p-2 rounded bg-gray-700 mr-2"
+        />
+        <input
+          type="number"
+          value={amount}
+          onChange={(e) => setAmount(e.target.value)}
+          className="p-2 rounded bg-gray-700 mr-2 w-24"
+        />
+        <button onClick={createCode} className="bg-blue-500 px-4 py-2 rounded">Create</button>
+      </div>
+      {message && <div className="text-yellow-400">{message}</div>}
+    </div>
+  );
+}
+
+export default AdminPanel;

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,5 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import './App.css';
+import Login from "./Login";
+import Profile from "./Profile";
+import AdminPanel from "./AdminPanel";
+import DiceGame from "./DiceGame";
+import SlotsGame from "./SlotsGame";
+import RouletteGame from "./RouletteGame";
+import PlinkoGame from "./PlinkoGame";
+import WheelGame from "./WheelGame";
 
 // Game Components
 const BlackjackGame = ({ tymCoins, setTymCoins }) => {
@@ -522,92 +530,88 @@ const CrashGame = ({ tymCoins, setTymCoins }) => {
 };
 
 function App() {
-  const [tymCoins, setTymCoins] = useState(() => {
-    const saved = localStorage.getItem('tymCoins');
-    return saved ? parseInt(saved) : 100;
+  const [user, setUser] = useState(() => {
+    const stored = localStorage.getItem('currentUser');
+    return stored ? JSON.parse(stored) : null;
   });
-  
+  const [tymCoins, setTymCoins] = useState(100);
   const [currentGame, setCurrentGame] = useState('blackjack');
+  const [page, setPage] = useState('games');
 
   useEffect(() => {
-    localStorage.setItem('tymCoins', tymCoins.toString());
+    if (user) setTymCoins(user.balance);
+  }, [user]);
+
+  useEffect(() => {
+    if (user) {
+      const updated = { ...user, balance: tymCoins };
+      setUser(updated);
+      const users = JSON.parse(localStorage.getItem('users') || '{}');
+      if (users[user.username]) {
+        users[user.username].balance = tymCoins;
+        localStorage.setItem('users', JSON.stringify(users));
+      }
+      localStorage.setItem('currentUser', JSON.stringify(updated));
+    }
   }, [tymCoins]);
 
-  const resetCoins = () => {
-    setTymCoins(100);
+  if (!user) {
+    return <Login onLogin={setUser} />;
+  }
+
+  const logout = () => {
+    setUser(null);
+    localStorage.removeItem('currentUser');
   };
 
-  return (
-    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-black">
-      {/* Header */}
-      <header className="bg-black bg-opacity-50 p-4">
-        <div className="max-w-6xl mx-auto flex justify-between items-center">
-          <h1 className="text-4xl font-bold text-yellow-400">🪙 TymCasino</h1>
-          <div className="flex items-center space-x-4">
-            <div className="text-white text-xl">
-              Balance: <span className="text-yellow-400 font-bold">{tymCoins.toFixed(2)} TymCoins</span>
-            </div>
-            <button 
-              onClick={resetCoins}
-              className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded"
-            >
-              Reset (100 TymCoins)
-            </button>
-          </div>
-        </div>
-      </header>
-
-      {/* Navigation */}
+  const showGames = (
+    <>
       <nav className="bg-black bg-opacity-30 p-4">
         <div className="max-w-6xl mx-auto">
-          <div className="flex justify-center space-x-8">
-            <button 
-              onClick={() => setCurrentGame('blackjack')}
-              className={`px-6 py-3 rounded-lg font-bold transition-all ${
-                currentGame === 'blackjack' 
-                  ? 'bg-yellow-500 text-black' 
-                  : 'bg-gray-700 text-white hover:bg-gray-600'
-              }`}
-            >
-              ♠ Blackjack
-            </button>
-            <button 
-              onClick={() => setCurrentGame('mines')}
-              className={`px-6 py-3 rounded-lg font-bold transition-all ${
-                currentGame === 'mines' 
-                  ? 'bg-yellow-500 text-black' 
-                  : 'bg-gray-700 text-white hover:bg-gray-600'
-              }`}
-            >
-              💣 Mines
-            </button>
-            <button 
-              onClick={() => setCurrentGame('crash')}
-              className={`px-6 py-3 rounded-lg font-bold transition-all ${
-                currentGame === 'crash' 
-                  ? 'bg-yellow-500 text-black' 
-                  : 'bg-gray-700 text-white hover:bg-gray-600'
-              }`}
-            >
-              🚀 Crash
-            </button>
+          <div className="flex flex-wrap justify-center space-x-4">
+            {['blackjack','mines','crash','dice','slots','roulette','plinko','wheel'].map(g => (
+              <button
+                key={g}
+                onClick={() => setCurrentGame(g)}
+                className={`px-4 py-2 m-1 rounded-lg font-bold transition-all ${currentGame===g?'bg-yellow-500 text-black':'bg-gray-700 text-white hover:bg-gray-600'}`}
+              >
+                {g}
+              </button>
+            ))}
           </div>
         </div>
       </nav>
-
-      {/* Main Game Area */}
       <main className="max-w-4xl mx-auto p-6">
         {currentGame === 'blackjack' && <BlackjackGame tymCoins={tymCoins} setTymCoins={setTymCoins} />}
         {currentGame === 'mines' && <MinesGame tymCoins={tymCoins} setTymCoins={setTymCoins} />}
         {currentGame === 'crash' && <CrashGame tymCoins={tymCoins} setTymCoins={setTymCoins} />}
+        {currentGame === 'dice' && <DiceGame user={user} setUser={setUser} />}
+        {currentGame === 'slots' && <SlotsGame user={user} setUser={setUser} />}
+        {currentGame === 'roulette' && <RouletteGame user={user} setUser={setUser} />}
+        {currentGame === 'plinko' && <PlinkoGame user={user} setUser={setUser} />}
+        {currentGame === 'wheel' && <WheelGame user={user} setUser={setUser} />}
       </main>
+    </>
+  );
 
-      {/* Footer */}
-      <footer className="bg-black bg-opacity-50 p-4 mt-8">
-        <div className="max-w-6xl mx-auto text-center text-white">
-          <p>🎲 TymCasino - Play Responsibly with TymCoins 🎲</p>
-          <p className="text-sm text-gray-400 mt-2">Virtual currency for entertainment purposes only</p>
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-gray-900 via-purple-900 to-black">
+      <header className="bg-black bg-opacity-50 p-4">
+        <div className="max-w-6xl mx-auto flex justify-between items-center">
+          <h1 className="text-4xl font-bold text-yellow-400">🪙 TymCasino</h1>
+          <div className="flex items-center space-x-4">
+            <div className="text-white text-xl">Balance: <span className="text-yellow-400 font-bold">{tymCoins.toFixed(2)} TymCoins</span></div>
+            <button onClick={()=>setPage('profile')} className="bg-gray-700 text-white px-3 py-1 rounded">Profile</button>
+            {user.isAdmin && <button onClick={()=>setPage('admin')} className="bg-gray-700 text-white px-3 py-1 rounded">Admin</button>}
+            <button onClick={logout} className="bg-red-600 text-white px-3 py-1 rounded">Logout</button>
+          </div>
         </div>
+      </header>
+      {page==='profile' && <Profile user={user} setUser={setUser} />}
+      {page==='admin' && user.isAdmin && <AdminPanel />}
+      {page==='games' && showGames}
+      <footer className="bg-black bg-opacity-50 p-4 mt-8 text-center text-white">
+        <p>🎲 TymCasino - Play Responsibly with TymCoins 🎲</p>
       </footer>
     </div>
   );

--- a/frontend/src/DiceGame.js
+++ b/frontend/src/DiceGame.js
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+
+function DiceGame({ user, setUser }) {
+  const [bet, setBet] = useState(10);
+  const [choice, setChoice] = useState(1);
+  const [result, setResult] = useState(null);
+
+  const play = () => {
+    if (bet > user.balance || bet <= 0) return;
+    const roll = Math.floor(Math.random() * 6) + 1;
+    let newBalance = user.balance - bet;
+    if (roll === parseInt(choice)) {
+      newBalance += bet * 6;
+      setResult(`Rolled ${roll}. You win!`);
+    } else {
+      setResult(`Rolled ${roll}. You lose.`);
+    }
+    const updated = { ...user, balance: newBalance };
+    setUser(updated);
+    const users = JSON.parse(localStorage.getItem('users') || '{}');
+    users[user.username].balance = newBalance;
+    localStorage.setItem('users', JSON.stringify(users));
+    localStorage.setItem('currentUser', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h2 className="text-2xl mb-4">Dice</h2>
+      <div className="mb-4">
+        <label className="mr-2">Bet:</label>
+        <input type="number" value={bet} onChange={(e)=>setBet(e.target.value)} className="p-1 text-black w-24" />
+      </div>
+      <div className="mb-4">
+        <label className="mr-2">Pick (1-6):</label>
+        <input type="number" value={choice} min="1" max="6" onChange={(e)=>setChoice(e.target.value)} className="p-1 text-black w-24" />
+      </div>
+      <button onClick={play} className="bg-yellow-500 text-black px-4 py-2 rounded">Roll</button>
+      {result && <div className="mt-4">{result}</div>}
+    </div>
+  );
+}
+
+export default DiceGame;

--- a/frontend/src/Login.js
+++ b/frontend/src/Login.js
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+
+function Login({ onLogin }) {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // simple hard-coded auth
+    if ((username === 'admin' && password === 'admin') ||
+        (username === 'user' && password === 'password')) {
+      const isAdmin = username === 'admin';
+      const stored = localStorage.getItem('users');
+      const users = stored ? JSON.parse(stored) : {};
+      if (!users[username]) {
+        users[username] = { balance: 100 };
+      }
+      localStorage.setItem('users', JSON.stringify(users));
+      const user = { username, isAdmin, balance: users[username].balance };
+      localStorage.setItem('currentUser', JSON.stringify(user));
+      onLogin(user);
+    } else {
+      setError('Invalid credentials');
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900 text-white">
+      <form onSubmit={handleSubmit} className="bg-gray-800 p-6 rounded-lg space-y-4">
+        <h2 className="text-2xl font-bold text-center">Login</h2>
+        {error && <div className="text-red-500">{error}</div>}
+        <input
+          type="text"
+          placeholder="Username"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full p-2 rounded bg-gray-700"
+        />
+        <input
+          type="password"
+          placeholder="Password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full p-2 rounded bg-gray-700"
+        />
+        <button type="submit" className="w-full bg-yellow-500 text-black py-2 rounded">Login</button>
+      </form>
+    </div>
+  );
+}
+
+export default Login;

--- a/frontend/src/PlinkoGame.js
+++ b/frontend/src/PlinkoGame.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+const multipliers = [0,1,2,3,5];
+
+function PlinkoGame({ user, setUser }) {
+  const [bet, setBet] = useState(10);
+  const [result, setResult] = useState('');
+
+  const drop = () => {
+    if (bet > user.balance || bet <= 0) return;
+    const mult = multipliers[Math.floor(Math.random()*multipliers.length)];
+    const win = bet * mult;
+    const newBalance = user.balance - bet + win;
+    setResult(`Landed on ${mult}x. ${win>0?`Won ${win}`:'Lost'}.`);
+    const updated = { ...user, balance: newBalance };
+    setUser(updated);
+    const users = JSON.parse(localStorage.getItem('users') || '{}');
+    users[user.username].balance = newBalance;
+    localStorage.setItem('users', JSON.stringify(users));
+    localStorage.setItem('currentUser', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h2 className="text-2xl mb-4">Plinko</h2>
+      <div className="mb-2">
+        <label className="mr-2">Bet:</label>
+        <input type="number" value={bet} onChange={(e)=>setBet(e.target.value)} className="p-1 text-black w-24" />
+      </div>
+      <button onClick={drop} className="bg-yellow-500 text-black px-4 py-2 rounded">Drop</button>
+      {result && <div className="mt-4">{result}</div>}
+    </div>
+  );
+}
+
+export default PlinkoGame;

--- a/frontend/src/Profile.js
+++ b/frontend/src/Profile.js
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+function Profile({ user, setUser }) {
+  const [code, setCode] = useState('');
+  const [message, setMessage] = useState('');
+
+  const redeem = () => {
+    const codes = JSON.parse(localStorage.getItem('codes') || '{}');
+    if (codes[code]) {
+      const amount = codes[code];
+      const updatedUser = { ...user, balance: user.balance + amount };
+      setUser(updatedUser);
+      const users = JSON.parse(localStorage.getItem('users') || '{}');
+      users[user.username].balance = updatedUser.balance;
+      localStorage.setItem('users', JSON.stringify(users));
+      localStorage.setItem('currentUser', JSON.stringify(updatedUser));
+      delete codes[code];
+      localStorage.setItem('codes', JSON.stringify(codes));
+      setMessage(`Added ${amount} coins!`);
+      setCode('');
+    } else {
+      setMessage('Invalid code');
+    }
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h2 className="text-2xl mb-4">Profile: {user.username}</h2>
+      <p className="mb-4">Balance: {user.balance} TymCoins</p>
+      <div className="mb-4">
+        <input
+          value={code}
+          onChange={(e) => setCode(e.target.value)}
+          placeholder="Redeem code"
+          className="p-2 rounded bg-gray-700 mr-2"
+        />
+        <button onClick={redeem} className="bg-green-500 px-4 py-2 rounded">Redeem</button>
+      </div>
+      {message && <div className="text-yellow-400">{message}</div>}
+    </div>
+  );
+}
+
+export default Profile;

--- a/frontend/src/RouletteGame.js
+++ b/frontend/src/RouletteGame.js
@@ -1,0 +1,47 @@
+import React, { useState } from 'react';
+
+function RouletteGame({ user, setUser }) {
+  const [bet, setBet] = useState(10);
+  const [choice, setChoice] = useState('red');
+  const [result, setResult] = useState('');
+
+  const spin = () => {
+    if (bet > user.balance || bet <= 0) return;
+    const number = Math.floor(Math.random()*37); //0-36
+    const colors = ['green','red','black'];
+    const color = number===0 ? 'green' : (number % 2 ? 'red' : 'black');
+    let newBalance = user.balance - bet;
+    if (color === choice && color !== 'green') {
+      newBalance += bet * 2;
+      setResult(`Landed ${number} ${color}. You win!`);
+    } else {
+      setResult(`Landed ${number} ${color}. You lose.`);
+    }
+    const updated = { ...user, balance: newBalance };
+    setUser(updated);
+    const users = JSON.parse(localStorage.getItem('users') || '{}');
+    users[user.username].balance = newBalance;
+    localStorage.setItem('users', JSON.stringify(users));
+    localStorage.setItem('currentUser', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h2 className="text-2xl mb-4">Roulette</h2>
+      <div className="mb-2">
+        <label className="mr-2">Bet:</label>
+        <input type="number" value={bet} onChange={(e)=>setBet(e.target.value)} className="p-1 text-black w-24" />
+      </div>
+      <div className="mb-4">
+        <select value={choice} onChange={(e)=>setChoice(e.target.value)} className="p-1 text-black">
+          <option value="red">Red</option>
+          <option value="black">Black</option>
+        </select>
+      </div>
+      <button onClick={spin} className="bg-yellow-500 text-black px-4 py-2 rounded">Spin</button>
+      {result && <div className="mt-4">{result}</div>}
+    </div>
+  );
+}
+
+export default RouletteGame;

--- a/frontend/src/SlotsGame.js
+++ b/frontend/src/SlotsGame.js
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+
+const symbols = ['🍒','🍋','🔔','7'];
+
+function SlotsGame({ user, setUser }) {
+  const [bet, setBet] = useState(10);
+  const [reels, setReels] = useState(['?','?','?']);
+  const [message, setMessage] = useState('');
+
+  const spin = () => {
+    if (bet > user.balance || bet <= 0) return;
+    const newReels = [0,1,2].map(()=>symbols[Math.floor(Math.random()*symbols.length)]);
+    setReels(newReels);
+    let newBalance = user.balance - bet;
+    if (newReels.every(r => r === newReels[0])) {
+      newBalance += bet * 5;
+      setMessage('Jackpot!');
+    } else if (new Set(newReels).size === 2) {
+      newBalance += bet * 2;
+      setMessage('Nice!');
+    } else {
+      setMessage('Try again');
+    }
+    const updated = { ...user, balance: newBalance };
+    setUser(updated);
+    const users = JSON.parse(localStorage.getItem('users') || '{}');
+    users[user.username].balance = newBalance;
+    localStorage.setItem('users', JSON.stringify(users));
+    localStorage.setItem('currentUser', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h2 className="text-2xl mb-4">Slots</h2>
+      <div className="mb-4">
+        <label className="mr-2">Bet:</label>
+        <input type="number" value={bet} onChange={(e)=>setBet(e.target.value)} className="p-1 text-black w-24" />
+      </div>
+      <button onClick={spin} className="bg-yellow-500 text-black px-4 py-2 rounded">Spin</button>
+      <div className="text-4xl my-4">{reels.join(' ')}</div>
+      {message && <div>{message}</div>}
+    </div>
+  );
+}
+
+export default SlotsGame;

--- a/frontend/src/WheelGame.js
+++ b/frontend/src/WheelGame.js
@@ -1,0 +1,36 @@
+import React, { useState } from 'react';
+
+const segments = [0,2,3,5,10];
+
+function WheelGame({ user, setUser }) {
+  const [bet, setBet] = useState(10);
+  const [result, setResult] = useState('');
+
+  const spin = () => {
+    if (bet > user.balance || bet <= 0) return;
+    const mult = segments[Math.floor(Math.random()*segments.length)];
+    const win = bet * mult;
+    const newBalance = user.balance - bet + win;
+    setResult(`Wheel landed on ${mult}x. ${win>0?`Won ${win}`:'Lost'}.`);
+    const updated = { ...user, balance: newBalance };
+    setUser(updated);
+    const users = JSON.parse(localStorage.getItem('users') || '{}');
+    users[user.username].balance = newBalance;
+    localStorage.setItem('users', JSON.stringify(users));
+    localStorage.setItem('currentUser', JSON.stringify(updated));
+  };
+
+  return (
+    <div className="p-6 text-white">
+      <h2 className="text-2xl mb-4">Wheel</h2>
+      <div className="mb-2">
+        <label className="mr-2">Bet:</label>
+        <input type="number" value={bet} onChange={(e)=>setBet(e.target.value)} className="p-1 text-black w-24" />
+      </div>
+      <button onClick={spin} className="bg-yellow-500 text-black px-4 py-2 rounded">Spin</button>
+      {result && <div className="mt-4">{result}</div>}
+    </div>
+  );
+}
+
+export default WheelGame;


### PR DESCRIPTION
## Summary
- add simple login page
- create profile page with code redemption
- add admin panel to create deposit codes
- implement extra games: dice, slots, roulette, plinko and wheel
- rework App to handle login state and new navigation

## Testing
- `pytest -q`
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_684200c39734832ea41268192b53eb46